### PR TITLE
Example of a unittest (_grab_csv_) with setUp and tearDown from cgould99

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# no .csvs
+*.csv
+
 # Distribution / packaging
 .Python
 build/

--- a/alfred/etl.py
+++ b/alfred/etl.py
@@ -468,7 +468,7 @@ are consistent with those specified in the script. It also assumes that the 'KCM
 in the 'Raw Data' directory.
 """
 
-def main():
+def unpack_interactive():
     raw_data_folder_name = input("Enter the name of the raw data folder: ")
     #unzip_folder_name = input("Enter the name of the folder to extract data: ")
     zip_filename = input("Enter the name of the zip file (include .zip): ")
@@ -511,7 +511,4 @@ def main():
                 dst_folder = os.path.join(all_folder, dir_name)
                 # Copy the folder to all_data
                 shutil.copytree(src_folder, dst_folder)
-if __name__ == "__main__":
-    main()
 
-main()

--- a/alfred/tests/test_etl.py
+++ b/alfred/tests/test_etl.py
@@ -1,5 +1,9 @@
 import os
+import tempfile
 import unittest
+import zipfile
+
+import pandas as pd
 
 import alfred
 
@@ -8,10 +12,36 @@ data_path = os.path.join(alfred.__path__[0], 'data')
 # tests on alfred.etl
 class test_ETL(unittest.TestCase):
 
-    def test_sort(self):
+    def setUp(self):
+        """
+        Unpack the zip
+        """
+        self.temp_dir = tempfile.mktemp(prefix="alfred_")
+
+        with zipfile.ZipFile(os.path.join(data_path, "test_data.zip")) as zip_ref:
+            zip_ref.extractall(self.temp_dir)
+
+    def test_grab_csv(self):
         """
         Testing the sort functions or some other description here.
         """
 
-        # example of reading a df from a zip using data_path above
-        df = pd.read_csv(os.path.join(data_path, "test_data.zip"))
+        # find the csvs extracted from the zip
+        result = alfred.etl.grab_csv(self.temp_dir)
+        assert result == ['14H0221_ProfileData_20180403084955(2).csv', '14H0221_ProfileData_20171027081821(2).csv', '0014_ProfileData_20161201100821(2).csv', '13J0014_ProfileData_20180802094539(2).csv', '0014_ProfileData_20161004063626(2).csv', '14H0221_ProfileData_20171005100537(3).csv', '0014_ProfileData_20170207092734(2).csv', '_ProfileData_20180425073946(2).csv', '14F0154_ProfileData_20171116125343(2).csv', '13J0014_ProfileData_20180801084738(2).csv', '_ProfileData_20180508065837(2).csv', '14B0059_ProfileData_20180403061303(2).csv', '0014_ProfileData_20160727062458(2).csv']
+
+        # this should return an empty list
+        result = alfred.etl.grab_csv(data_path)
+        assert result == []
+
+    def tearDown(self):
+        """
+        Remove .csv files
+        """
+        for file_name in os.listdir(self.temp_dir):
+            file_path = os.path.join(self.temp_dir, file_name)
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+
+        # remove test dir
+        os.rmdir(self.temp_dir)


### PR DESCRIPTION
This patch actually contains two unrelated components.  The first is indeed the example unittest on the tin, but it also modifies the _.gitignore_ to not include .csv files.

GLHF